### PR TITLE
106 feature image compression

### DIFF
--- a/app/src/main/java/com/example/nostack/services/ImageUploader.java
+++ b/app/src/main/java/com/example/nostack/services/ImageUploader.java
@@ -1,8 +1,12 @@
 package com.example.nostack.services;
 
+import android.content.ContentResolver;
+import android.content.Context;
 import android.graphics.Bitmap;
+import android.graphics.ImageDecoder;
 import android.net.Uri;
 import android.os.Environment;
+import android.provider.MediaStore;
 import android.util.Log;
 
 import com.google.firebase.storage.FirebaseStorage;
@@ -89,5 +93,38 @@ public class ImageUploader {
         return imageUri;
     }
 
+    /**
+     * Compress image
+     *
+     * @param imageUri The URI of the image to compress
+     * @param quality  The quality (in decimal 0 < quality <= 1) of the compressed image
+     * @return The URI of the compressed image
+     */
+    public static Uri compressImage(Uri imageUri, double quality, Context context) throws IOException{
+        // Check if quality is within domain
+        if(quality <= 0 || quality > 1) {
+            throw new IllegalArgumentException("Quality must be in the range: 0 < quality <= 1");
+        }
 
+        // Check if imageUri is null
+        if (imageUri == null) {
+            throw new IllegalArgumentException("Image URI cannot be null");
+        }
+
+        // Convert to bitmap
+        Bitmap imageBitmap = MediaStore.Images.Media.getBitmap(context.getContentResolver(), imageUri);
+
+        // Create temporary file to cache compressed image
+        String filename = UUID.randomUUID().toString() + ".jpg";
+        File file = new File(context.getCacheDir(), filename);
+
+        // Compress image
+        FileOutputStream out = new FileOutputStream(file);
+        imageBitmap.compress(Bitmap.CompressFormat.JPEG, (int)(quality * 100), out);
+        out.flush();
+        out.close();
+
+        // Return URI to compressed image
+        return Uri.fromFile(file);
+    }
 }

--- a/app/src/main/java/com/example/nostack/views/organizer/OrganizerEventCreate.java
+++ b/app/src/main/java/com/example/nostack/views/organizer/OrganizerEventCreate.java
@@ -322,7 +322,15 @@ public class OrganizerEventCreate extends Fragment {
     }
 
     private void storeToDbEventWithBanner(Uri imageUri, Event event) {
-        imageUploader.uploadImage("event/banner/", imageUri, new ImageUploader.UploadListener() {
+        Uri compressedImageUri = null;
+
+        try {
+            compressedImageUri = ImageUploader.compressImage(imageUri, 0.5, getContext());
+        } catch (Exception e) {
+            Log.w("Event creation", "Image compression failed:", e);
+        }
+
+        imageUploader.uploadImage("event/banner/", compressedImageUri, new ImageUploader.UploadListener() {
             @Override
             public void onUploadSuccess(String imageUrl) {
                 event.setEventBannerImgUrl(imageUrl);

--- a/app/src/main/java/com/example/nostack/views/user/UserProfile.java
+++ b/app/src/main/java/com/example/nostack/views/user/UserProfile.java
@@ -23,6 +23,8 @@ import com.example.nostack.models.Image;
 import com.example.nostack.services.ImageUploader;
 import com.example.nostack.viewmodels.UserViewModel;
 
+import java.io.IOException;
+
 import javax.annotation.Nullable;
 
 /**
@@ -84,7 +86,16 @@ public class UserProfile extends Fragment {
      * @param imageUri The Uri of the image to be uploaded
      */
     private void uploadProfileImage(Uri imageUri) {
-        imageUploader.uploadImage("user/profile/", imageUri, new ImageUploader.UploadListener() {
+        Uri compressedImageUri = null;
+
+        try{
+            compressedImageUri = imageUploader.compressImage(imageUri, 0.5, getContext());
+        }
+        catch (IOException e){
+            Log.w("User edit", "Profile image compression failed:", e);
+        }
+
+        imageUploader.uploadImage("user/profile/", compressedImageUri, new ImageUploader.UploadListener() {
             @Override
             public void onUploadSuccess(String imageUrl) {
                 // Update user profile with the downloaded image URL

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -1,5 +1,5 @@
 // Top-level build file where you can add configuration options common to all sub-projects/modules.
 plugins {
-    id("com.android.application") version "8.3.0" apply false
+    id("com.android.application") version "8.3.1" apply false
     id("com.google.gms.google-services") version "4.4.1" apply false
 }


### PR DESCRIPTION
Added image compression
By default at a ratio of 50%.

Changed user and event images to be compressed.

Note: test on your device if image selection works, since on my pixel 3a emulator it was giving some weird error (due to google pictures, not due to code) but on my physical device it worked fine and also a pixel 5 emulator also worked fine. Maybe test on a pixel 3a emulator to be sure.